### PR TITLE
Update punctuation for the French translation

### DIFF
--- a/custom/config-katex.md
+++ b/custom/config-katex.md
@@ -2,7 +2,7 @@
 
 <Environment type="node" />
 
-Créer `./setup/katex.ts` avec le contenu suivant:
+Créer `./setup/katex.ts` avec le contenu suivant :
 
 ```ts
 import { defineKatexSetup } from '@slidev/types'

--- a/custom/config-mermaid.md
+++ b/custom/config-mermaid.md
@@ -2,7 +2,7 @@
 
 <Environment type="client" />
 
-Créer `./setup/mermaid.ts` avec le contenu suivant:
+Créer `./setup/mermaid.ts` avec le contenu suivant :
 
 ```ts
 import { defineMermaidSetup } from '@slidev/types'

--- a/custom/config-monaco.md
+++ b/custom/config-monaco.md
@@ -4,7 +4,7 @@
 
 > Par défaut, uniquement Monaco est activé uniquement en mode développement. Pour le faire fonctionner sur la version SPA, ajoutez `monaco: true` à vos configurations frontmatter.
 
-Créer `./setup/monaco.ts` avec le contenu suivant:
+Créer `./setup/monaco.ts` avec le contenu suivant :
 
 ```ts
 import { defineMonacoSetup } from '@slidev/types'
@@ -18,7 +18,7 @@ En savoir plus sur [la configuration de Monaco](https://github.com/Microsoft/mon
 
 ## Utilisation
 
-Pour utiliser Monaco dans vos diapositives, ajoutez simplement `{monaco}` à vos extraits de code:
+Pour utiliser Monaco dans vos diapositives, ajoutez simplement `{monaco}` à vos extraits de code :
 
 ~~~js
 //```js
@@ -46,7 +46,7 @@ plusOne.value++ // error
 
 ## Exporter
 
-Par défaut, Monaco fonctionnera UNIQUEMENT en mode `dev`. Si vous souhaitez également l'avoir disponible dans le SPA exporté, vous pouvez le configurer dans votre frontmatter:
+Par défaut, Monaco fonctionnera UNIQUEMENT en mode `dev`. Si vous souhaitez également l'avoir disponible dans le SPA exporté, vous pouvez le configurer dans votre frontmatter :
 
 ```yaml
 ---

--- a/custom/config-vite.md
+++ b/custom/config-vite.md
@@ -6,7 +6,7 @@ Slidev est alimenté par [Vite](http://vitejs.dev/) sous le capot. Cela signifie
 
 La configuration `vite.config.ts` sera respectée si vous en avez une.
 
-Slidev a les plugins suivants préconfigurés:
+Slidev a les plugins suivants préconfigurés :
 
 - [@vitejs/plugin-vue](https://github.com/vitejs/vite/tree/main/packages/plugin-vue)
 - [vite-plugin-md](https://github.com/antfu/vite-plugin-md)

--- a/custom/directory-structure.md
+++ b/custom/directory-structure.md
@@ -2,7 +2,7 @@
 
 Slidev utilise certaines conventions de structure de répertoires pour minimiser la surface de configuration et rendre les extensions de fonctionnalités flexibles et intuitives.
 
-La structure de base est la suivante:
+La structure de base est la suivante :
 
 ```bash
 your-slidev/
@@ -24,7 +24,7 @@ Conventions: `./components/*.{vue,js,ts,jsx,tsx,md}`
 
 Les composants à l'intérieur de ce répertoire peuvent être directement utilisés dans les diapositives Markdown avec le même nom de composant que le nom de fichier.
 
-Par exemple:
+Par exemple :
 
 ```bash
 your-slidev/
@@ -54,7 +54,7 @@ Slidev fournit également des [composants intégrés](/builtin/components) que v
 
 ## Mises en page
 
-Conventions: `./layouts/*.{vue,js,ts,jsx,tsx}`
+Conventions : `./layouts/*.{vue,js,ts,jsx,tsx}`
 
 ```
 your-slidev/
@@ -74,7 +74,7 @@ layout: my-cool-theme
 
 Si la mise en page que vous fournissez porte le même nom qu'une mise en page intégrée ou une mise en page de thème, votre mise en page personnalisée prévaudra sur la mise en page intégrée / thème. L'ordre de priorité est `local > thème > intégré`.
 
-Dans le composant de mise en page, utilisez `<slot />` pour le contenu de la diapositive. Par exemple:
+Dans le composant de mise en page, utilisez `<slot />` pour le contenu de la diapositive. Par exemple :
 
 ```html
 <!-- default.vue -->
@@ -87,13 +87,13 @@ Dans le composant de mise en page, utilisez `<slot />` pour le contenu de la dia
 
 ## Public
 
-Conventions: `./public/*`
+Conventions : `./public/*`
 
 Les actifs de ce répertoire seront servis à la racine du chemin `/` pendant le développement, et copiés à la racine du répertoire dist tels quels. En savoir plus sur [le répertoire `public` de Vite](https://vitejs.dev/guide/assets.html#the-public-directory).
 
 ## Style
 
-Conventions: `./style.css` | `./styles/index.{css,js,ts}`
+Conventions : `./style.css` | `./styles/index.{css,js,ts}`
 
 Les fichiers suivant cette convention seront injectés à la racine de l'application. Si vous devez importer plusieurs entrées CSS, vous pouvez créer la structure suivante et gérer vous-même l'ordre d'importation.
 
@@ -115,7 +115,7 @@ import './code.css'
 import './layouts.css'
 ```
 
-Les styles seront traités par [Windi CSS](http://windicss.org/) et [PostCSS](https://postcss.org/), vous pouvez donc utiliser l'imbrication css et [at-directives](https://windicss.org/features/directives.html) prêt à l'emploi. Par exemple:
+Les styles seront traités par [Windi CSS](http://windicss.org/) et [PostCSS](https://postcss.org/), vous pouvez donc utiliser l'imbrication css et [at-directives](https://windicss.org/features/directives.html) prêt à l'emploi. Par exemple :
 
 ```less
 .slidev-layout {
@@ -139,11 +139,11 @@ Les styles seront traités par [Windi CSS](http://windicss.org/) et [PostCSS](ht
 
 ## `index.html`
 
-Conventions: `index.html`
+Conventions : `index.html`
 
-Le `index.html` offre la possibilité d'injecter des balises meta et/ou des scripts dans le` index.html` principal
+Le `index.html` offre la possibilité d'injecter des balises meta et/ou des scripts dans le `index.html` principal
 
-Par exemple, pour le `index.html` personnalisé suivant:
+Par exemple, pour le `index.html` personnalisé suivant :
 
 ```html
 <!-- ./index.html -->
@@ -157,7 +157,7 @@ Par exemple, pour le `index.html` personnalisé suivant:
 </body>
 ```
 
-Le fichier `index.html` final hébergé sera:
+Le fichier `index.html` final hébergé sera :
 
 ```html
 <!DOCTYPE html>

--- a/custom/highlighters.md
+++ b/custom/highlighters.md
@@ -1,6 +1,6 @@
 Surligneurs
 
-Slidev est livré avec deux surligneurs de syntaxe parmi lesquels vous pouvez choisir:
+Slidev est livré avec deux surligneurs de syntaxe parmi lesquels vous pouvez choisir :
 
 - [Prism](https://prismjs.com/)
 - [Shiki](https://github.com/shikijs/shiki)
@@ -11,12 +11,12 @@ Slidev est livré avec deux surligneurs de syntaxe parmi lesquels vous pouvez ch
 
 Les thèmes Slidev prennent généralement en charge Prism et Shiki, mais selon le thème que vous utilisez, il se peut qu'il ne prenne en charge que l'un d'entre eux.
 
-Lorsque vous avez le choix, le compromis est essentiellement:
+Lorsque vous avez le choix, le compromis est essentiellement :
 
 - **Prism** pour une personnalisation plus facile
 - **Shiki** pour une mise en évidence plus précise
 
-Par défaut, Slidev utilise Prism. Vous pouvez le changer en modifiant votre frontmatter:
+Par défaut, Slidev utilise Prism. Vous pouvez le changer en modifiant votre frontmatter :
 
 ```yaml
 ---
@@ -32,7 +32,7 @@ Pour configurer votre Prism, vous pouvez simplement importer le thème css ou ut
 
 <Environment type="node" />
 
-Créer un fichier `./setup/shiki.ts` avec le contenu suivant:
+Créer un fichier `./setup/shiki.ts` avec le contenu suivant :
 
 ```ts
 /* ./setup/shiki.ts */
@@ -50,7 +50,7 @@ export default defineShikiSetup(() => {
 
 Reportez-vous à la [documentation de Shiki](https://github.com/shikijs/shiki/blob/master/docs/themes.md#all-themes) pour les noms de thèmes disponibles.
 
-Ou si vous souhaitez utiliser votre propre thème:
+Ou si vous souhaitez utiliser votre propre thème :
 
 ```ts
 /* ./setup/shiki.ts */

--- a/guide/animations.md
+++ b/guide/animations.md
@@ -4,7 +4,7 @@
 
 ### `v-click`
 
-Pour appliquer des "animations de clic" aux éléments, vous pouvez utiliser la directive `v-click` ou les composants` <v-click> `
+Pour appliquer des "animations de clic" aux éléments, vous pouvez utiliser la directive `v-click` ou les composants `<v-click>`
 
 ```md
 # Hello
@@ -26,7 +26,7 @@ Bonjour!
 
 ### `v-after`
 
-L'utilisation de `v-after` est similaire à` v-click` mais cela rendra l'élément visible lorsque le `v-click` précédent sera déclenché.
+L'utilisation de `v-after` est similaire à `v-click` mais cela rendra l'élément visible lorsque le `v-click` précédent sera déclenché.
 
 ```md
 <div v-click>Hello</div>
@@ -54,7 +54,7 @@ Un élément deviendra visible à chaque fois que vous cliquerez sur "suivant".
 
 ### Nombre de clics personnalisés
 
-Par défaut, Slidev compte le nombre d'étapes nécessaires avant de passer à la diapositive suivante. Vous pouvez remplacer ce paramètre en passant l'option frontmatter `clicks`:
+Par défaut, Slidev compte le nombre d'étapes nécessaires avant de passer à la diapositive suivante. Vous pouvez remplacer ce paramètre en passant l'option frontmatter `clicks` :
 
 ```yaml
 ---
@@ -93,7 +93,7 @@ clicks: 3
 
 ### Transitions d'éléments
 
-Lorsque vous appliquez la directive `v-click` à vos éléments, elle y attache le nom de classe` slidev-vclick-target`. Lorsque les éléments sont masqués, le nom de classe `slidev-vclick-hidden` sera également attaché. Par exemple:
+Lorsque vous appliquez la directive `v-click` à vos éléments, elle y attache le nom de classe` slidev-vclick-target`. Lorsque les éléments sont masqués, le nom de classe `slidev-vclick-hidden` sera également attaché. Par exemple :
 
 ```html
 <div class="slidev-vclick-target slidev-vclick-hidden">Text</div>
@@ -105,7 +105,7 @@ Après un clic, il deviendra
 <div class="slidev-vclick-target">Text</div>
 ```
 
-Par défaut, une transition d'opacité subtile est appliquée à ces classes:
+Par défaut, une transition d'opacité subtile est appliquée à ces classes :
 
 ```css
 // the default
@@ -122,7 +122,7 @@ Par défaut, une transition d'opacité subtile est appliquée à ces classes:
 
 Vous pouvez les remplacer pour personnaliser les effets de transition dans vos feuilles de style personnalisées.
 
-Par exemple, vous pouvez réaliser les transitions de mise à l'échelle en:
+Par exemple, vous pouvez réaliser les transitions de mise à l'échelle en :
 
 ```css
 // styles.css
@@ -166,9 +166,9 @@ Slidev a [@vueuse/motion](https://motion.vueuse.org/) intégré. Vous pouvez uti
 </div>
 ```
 
-Le texte `Slidev` passera de` -80px` à sa position d'origine lors de l'initialisation.
+Le texte `Slidev` passera de `-80px` à sa position d'origine lors de l'initialisation.
 
-> Remarque: Slidev précharge la diapositive suivante pour les performances, ce qui signifie que les animations peuvent démarrer avant que vous ne naviguiez vers la page. Pour que cela fonctionne correctement, vous pouvez désactiver le préchargement pour la diapositive particulière
+> Remarque : Slidev précharge la diapositive suivante pour les performances, ce qui signifie que les animations peuvent démarrer avant que vous ne naviguiez vers la page. Pour que cela fonctionne correctement, vous pouvez désactiver le préchargement pour la diapositive particulière
 >
 > ```md
 > ---

--- a/guide/exporting.md
+++ b/guide/exporting.md
@@ -29,7 +29,7 @@ $ slidev export --format png
 
 ## Single-Page Application (SPA)
 
-Vous pouvez également créer les diapositives dans un SPA auto-hébergeable:
+Vous pouvez également créer les diapositives dans un SPA auto-hébergeable :
 
 ```bash
 $ slidev build
@@ -39,7 +39,7 @@ L'application générée sera disponible sous `dist/` et vous pourrez ensuite l'
 
 ### Chemin de base
 
-Pour déployer vos diapositives sous des sous-itinéraires, vous devrez passer l'option `--base`. Par exemple:
+Pour déployer vos diapositives sous des sous-itinéraires, vous devrez passer l'option `--base`. Par exemple :
 
 ```bash
 $ slidev build --base /talks/my-cool-talk/
@@ -49,7 +49,7 @@ Reportez-vous à la [documentation de Vite](https://vitejs.dev/guide/build.html#
 
 ### Fournir un PDF téléchargeable
 
-Vous pouvez fournir un PDF téléchargeable aux téléspectateurs de votre SPA. Vous pouvez l'activer avec la configuration suivante:
+Vous pouvez fournir un PDF téléchargeable aux téléspectateurs de votre SPA. Vous pouvez l'activer avec la configuration suivante :
 
 ```md
 ---

--- a/guide/index.md
+++ b/guide/index.md
@@ -41,13 +41,13 @@ Slidev est rendu possible en combinant ces outils et technologies.
 
 ### Création de votre première présentation
 
-Avec NPM:
+Avec NPM :
 
 ```bash
 $ npm init slidev
 ```
 
-Avec Yarn:
+Avec Yarn :
 
 ```bash
 $ yarn create slidev
@@ -79,7 +79,7 @@ Exécutez `slidev --help` pour plus d'options disponibles.
 
 ### Syntaxe de Markdown
 
-Slidev lit votre fichier `slides.md` sous la racine de votre projet et les convertit en diapositives. Chaque fois que vous y apportez des modifications, le contenu des diapositives est mis à jour immédiatement. Par exemple:
+Slidev lit votre fichier `slides.md` sous la racine de votre projet et les convertit en diapositives. Chaque fois que vous y apportez des modifications, le contenu des diapositives est mis à jour immédiatement. Par exemple :
 
 ~~~md
 # Slidev

--- a/guide/install.md
+++ b/guide/install.md
@@ -6,13 +6,13 @@
 
 La meilleure façon de commencer est d'utiliser notre modèle de démarrage officiel.
 
-Avec NPM:
+Avec NPM :
 
 ```bash
 $ npm init slidev@latest
 ```
 
-Avec Yarn:
+Avec Yarn :
 
 ```bash
 $ yarn create slidev
@@ -24,7 +24,7 @@ Il contient également la configuration de base et une courte démo avec des ins
 
 ## Installer manuellement
 
-Si vous préférez toujours installer Slidev manuellement ou souhaitez l'intégrer dans vos projets existants, vous pouvez faire:
+Si vous préférez toujours installer Slidev manuellement ou souhaitez l'intégrer dans vos projets existants, vous pouvez faire :
 
 ```bash
 $ npm install @slidev/cli @slidev/theme-default

--- a/guide/recording.md
+++ b/guide/recording.md
@@ -12,6 +12,6 @@ Cliquez sur le bouton <carbon-user-avatar class="inline-icon-btn"/> dans le pann
 
 Cliquez sur le bouton <carbon-video class="inline-icon-btn"/> dans le panneau de navigation pour ouvrir une boîte de dialogue. Ici, vous pouvez choisir d'enregistrer votre caméra intégrée dans vos diapositives ou de les séparer en deux fichiers vidéo.
 
-Cette fonctionnalité est alimentée par [RecordRTC](https://github.com/muaz-khan/RecordRTC) et utilise l '[API WebRTC](https://webrtc.org/).
+Cette fonctionnalité est alimentée par [RecordRTC](https://github.com/muaz-khan/RecordRTC) et utilise l'[API WebRTC](https://webrtc.org/).
 
 ![](/screenshots/recording.png)

--- a/guide/syntax.md
+++ b/guide/syntax.md
@@ -32,7 +32,7 @@ Vous pouvez directement utiliser les composants Windi CSS et Vue pour styliser e
 
 ## Front Matter & Layouts
 
-Vous pouvez spécifier des mises en page et d'autres métadonnées pour chaque diapositive en convertissant les séparateurs en [blocs de présentation](https://jekyllrb.com/docs/front-matter/). Chaque avant-propos commence par un triple tiret et se termine par un autre. Les textes entre eux sont des objets de données au format [YAML](https://www.cloudbees.com/blog/yaml-tutorial-everything-you-need-get-started/). Par exemple:
+Vous pouvez spécifier des mises en page et d'autres métadonnées pour chaque diapositive en convertissant les séparateurs en [blocs de présentation](https://jekyllrb.com/docs/front-matter/). Chaque avant-propos commence par un triple tiret et se termine par un autre. Les textes entre eux sont des objets de données au format [YAML](https://www.cloudbees.com/blog/yaml-tutorial-everything-you-need-get-started/). Par exemple :
 
 ~~~md
 ---
@@ -197,7 +197,7 @@ Vous pouvez parcourir et rechercher toutes les icônes disponibles avec [Icônes
 
 ### Icônes de style
 
-Vous pouvez styliser les icônes comme les autres éléments HTML. Par exemple:
+Vous pouvez styliser les icônes comme les autres éléments HTML. Par exemple :
 
 ```html
 <uim-rocket />
@@ -211,7 +211,7 @@ Vous pouvez styliser les icônes comme les autres éléments HTML. Par exemple:
 
 ## Configurations
 
-Toutes les configurations nécessaires peuvent être définies dans le fichier Markdown. Par exemple:
+Toutes les configurations nécessaires peuvent être définies dans le fichier Markdown. Par exemple :
 
 ```md
 ---
@@ -267,7 +267,7 @@ En savoir plus: [Démo](https://sli.dev/demo/starter/8) | [KaTeX](https://katex.
 
 Vous pouvez également créer des diagrammes / graphiques à partir de descriptions textuelles dans votre Markdown, alimenté par [Mermaid](https://mermaid-js.github.io/mermaid).
 
-Les blocs de code marqués comme `mermaid` seront convertis en digrammes, par exemple:
+Les blocs de code marqués comme `mermaid` seront convertis en digrammes, par exemple :
 
 ~~~md
 //```mermaid
@@ -345,7 +345,7 @@ background: https://sli.dev/foo.png
 Page de couverture
 ```
 
-Ils finiront par être équivalents à la page suivante:
+Ils finiront par être équivalents à la page suivante :
 
 ```md
 ---
@@ -361,7 +361,7 @@ Page de couverture
 
 ### Réutilisation de la page
 
-Avec la prise en charge des entrées multiples, la réutilisation des pages peut être simple. Par exemple:
+Avec la prise en charge des entrées multiples, la réutilisation des pages peut être simple. Par exemple :
 
 ```yaml
 ---

--- a/guide/why.md
+++ b/guide/why.md
@@ -10,7 +10,7 @@ Lorsque vous travaillez avec des éditeurs WYSIWYG, il est facile de se laisser 
 
 ![](/screenshots/cover.png)
 
-Voici quelques-unes des fonctionnalités les plus intéressantes de Slidev:
+Voici quelques-unes des fonctionnalités les plus intéressantes de Slidev :
 
 ## Basé sur Markdown
 
@@ -58,13 +58,13 @@ Apprenez-en plus à ce sujet dans la [documentation d'exportation](/guide/export
 
 ## Essaie
 
-Jouer avec Slidev vous en dira plus que mille mots. Vous n'êtes qu'à une seule commande:
+Jouer avec Slidev vous en dira plus que mille mots. Vous n'êtes qu'à une seule commande :
 
 ```bash
 $ npm init slidev
 ```
 
-Ou en avoir un aperçu rapide:
+Ou en avoir un aperçu rapide :
 
 <div class="aspect-9/16 relative">
 <iframe class="rounded w-full shadow-md border-none" src="https://www.youtube.com/embed/eW7v-2ZKZOU" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>

--- a/themes/write-a-theme.md
+++ b/themes/write-a-theme.md
@@ -1,6 +1,6 @@
 # Ecrire un thème
 
-Pour commencer, nous vous recommandons d'utiliser notre générateur pour échafauder votre premier thème
+Pour commencer, nous vous recommandons d'utiliser notre générateur pour créer votre premier thème
 
 ```bash
 $ npm init slidev-theme
@@ -10,7 +10,7 @@ Ensuite, vous pouvez le modifier et jouer avec. Vous pouvez également vous réf
 
 ## Aptitude
 
-Un thème peut contribuer aux points suivants:
+Un thème peut contribuer aux points suivants :
 
 - Styles globaux
 - Fournir des polices Web
@@ -21,10 +21,10 @@ Un thème peut contribuer aux points suivants:
 
 ## Conventions
 
-Les thèmes sont publiés dans le registre npm et doivent respecter les conventions ci-dessous:
+Les thèmes sont publiés dans le registre npm et doivent respecter les conventions ci-dessous :
 
 - Le nom du package doit commencer par `slidev-theme-`, par exemple: `slidev-theme-awesome`
-- Ajoutez `slidev-theme` et` slidev` dans le champ `keywords` de votre` package.json`
+- Ajoutez `slidev-theme` et `slidev` dans le champ `keywords` de votre `package.json`
 
 ## Installer
 
@@ -50,7 +50,7 @@ En option, vous pouvez également ajouter des scripts à votre `package.json`
 }
 ```
 
-Pour publier votre thème, lancez simplement `npm publish` et vous êtes prêt à partir. Il n'y a pas de processus de construction requis (ce qui signifie que vous pouvez publier directement les fichiers `.vue` et` .ts`, Slidev est assez intelligent pour les comprendre).
+Pour publier votre thème, lancez simplement `npm publish` et vous êtes prêt à partir. Il n'y a pas de processus de construction requis (ce qui signifie que vous pouvez publier directement les fichiers `.vue` et `.ts`, Slidev est assez intelligent pour les comprendre).
 
 Les points de contribution de thème suivent les mêmes conventions que la personnalisation locale, veuillez vous référer à [la documentation pour les conventions](/custom/).
 
@@ -86,7 +86,7 @@ html.dark {
 }
 ```
 
-Slidev bascule une classe `dark` sur l'élément` html` de la page pour changer de schéma de couleur.
+Slidev bascule une classe `dark` sur l'élément `html` de la page pour changer de schéma de couleur.
 
 ## Surligneur
 


### PR DESCRIPTION
In French, some punctuation needs a space before it.
For example: `Hello!` become `Bonjour !`.
More information [in this article](https://www.blogdumoderateur.com/regles-ponctuation-typographie/).